### PR TITLE
Feat/countdown logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@dcl/ui-env": "^1.5.1",
         "@reduxjs/toolkit": "^2.11.2",
         "decentraland-connect": "^10.0.0",
-        "decentraland-ui2": "^1.1.3",
+        "decentraland-ui2": "^1.1.4",
         "i18next": "^25.7.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -8469,9 +8469,9 @@
       }
     },
     "node_modules/decentraland-ui2": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-1.1.3.tgz",
-      "integrity": "sha512-LcFJjRwjmk8NyBKUykiqJdRbmvngT3D3dDQBIb13mWYnxm+z/Nn+6Wbk4n56SMI6eIWpvweW99xMnOHbZ6QF1Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-1.1.4.tgz",
+      "integrity": "sha512-0w0d+qo8A/wElql+LSqi+dPHa6T11rLrogqsml8wQYfGCmnte4gf102GwNOMY1Tm+ER69YUcu6QUISWa4rYF1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@contentful/rich-text-react-renderer": "^16.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@dcl/ui-env": "^1.5.1",
     "@reduxjs/toolkit": "^2.11.2",
     "decentraland-connect": "^10.0.0",
-    "decentraland-ui2": "^1.1.3",
+    "decentraland-ui2": "^1.1.4",
     "i18next": "^25.7.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/BestNewScene/BestNewScene.tsx
+++ b/src/components/BestNewScene/BestNewScene.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo } from "react"
+import { type FC, memo, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { type SceneRowData, ScenesTable, dclTable } from "decentraland-ui2"
 import {
@@ -25,18 +25,21 @@ export const BestNewScene: FC<BestNewSceneProps> = memo(
   ({ sceneRow, onMobileRowClick }) => {
     const { t } = useTranslation()
 
-    const newColumns: dclTable.Column<NewRow>[] = [
-      {
-        id: "new",
-        header: t("liveLeaderboard.rankHeader"),
-        cellPadding: 0,
-        render: (row) => (
-          <NewCell key={row.key}>
-            <NewBadge>{t("bestNewScene.newBadge")}</NewBadge>
-          </NewCell>
-        ),
-      },
-    ]
+    const newColumns: dclTable.Column<NewRow>[] = useMemo(
+      () => [
+        {
+          id: "new",
+          header: t("liveLeaderboard.rankHeader"),
+          cellPadding: 0,
+          render: (row) => (
+            <NewCell key={row.key}>
+              <NewBadge>{t("bestNewScene.newBadge")}</NewBadge>
+            </NewCell>
+          ),
+        },
+      ],
+      [t]
+    )
 
     return (
       <BestNewSceneContainer>

--- a/src/components/BestNewScene/BestNewScene.tsx
+++ b/src/components/BestNewScene/BestNewScene.tsx
@@ -16,39 +16,42 @@ type NewRow = {
 
 type BestNewSceneProps = {
   sceneRow: SceneRowData
+  onMobileRowClick?: (row: SceneRowData, index: number) => void
 }
 
 const newRows: NewRow[] = [{ key: "new" }]
 
-export const BestNewScene: FC<BestNewSceneProps> = memo(({ sceneRow }) => {
-  const { t } = useTranslation()
+export const BestNewScene: FC<BestNewSceneProps> = memo(
+  ({ sceneRow, onMobileRowClick }) => {
+    const { t } = useTranslation()
 
-  const newColumns: dclTable.Column<NewRow>[] = [
-    {
-      id: "new",
-      header: t("liveLeaderboard.rankHeader"),
-      cellPadding: 0,
-      render: (row) => (
-        <NewCell key={row.key}>
-          <NewBadge>{t("bestNewScene.newBadge")}</NewBadge>
-        </NewCell>
-      ),
-    },
-  ]
+    const newColumns: dclTable.Column<NewRow>[] = [
+      {
+        id: "new",
+        header: t("liveLeaderboard.rankHeader"),
+        cellPadding: 0,
+        render: (row) => (
+          <NewCell key={row.key}>
+            <NewBadge>{t("bestNewScene.newBadge")}</NewBadge>
+          </NewCell>
+        ),
+      },
+    ]
 
-  return (
-    <BestNewSceneContainer>
-      <BestNewSceneTitle>{t("bestNewScene.title")}</BestNewSceneTitle>
-      <BestNewSceneWrapper>
-        <NewTableWrapper>
-          <dclTable.Table
-            columns={newColumns}
-            rows={newRows}
-            hoverEffect={false}
-          />
-        </NewTableWrapper>
-        <ScenesTable rows={[sceneRow]} />
-      </BestNewSceneWrapper>
-    </BestNewSceneContainer>
-  )
-})
+    return (
+      <BestNewSceneContainer>
+        <BestNewSceneTitle>{t("bestNewScene.title")}</BestNewSceneTitle>
+        <BestNewSceneWrapper>
+          <NewTableWrapper>
+            <dclTable.Table
+              columns={newColumns}
+              rows={newRows}
+              hoverEffect={false}
+            />
+          </NewTableWrapper>
+          <ScenesTable rows={[sceneRow]} onMobileRowClick={onMobileRowClick} />
+        </BestNewSceneWrapper>
+      </BestNewSceneContainer>
+    )
+  }
+)

--- a/src/components/LiveLeaderboard/Countdown/Countdown.styled.ts
+++ b/src/components/LiveLeaderboard/Countdown/Countdown.styled.ts
@@ -1,0 +1,54 @@
+import { Box, Typography, dclColors, styled } from "decentraland-ui2"
+
+const CountdownWrapper = styled(Box)(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: theme.spacing(2),
+  width: "100%",
+  padding: theme.spacing(6),
+  textAlign: "center",
+  background: "rgba(0, 0, 0, 0.4)",
+  borderRadius: theme.spacing(3),
+  [theme.breakpoints.down("sm")]: {
+    padding: theme.spacing(4),
+    borderRadius: theme.spacing(2),
+  },
+}))
+
+const CountdownTitle = styled(Typography)(({ theme }) => ({
+  fontSize: "32px",
+  fontWeight: 700,
+  color: theme.palette.text.primary,
+  [theme.breakpoints.down("sm")]: {
+    fontSize: "24px",
+  },
+}))
+
+const CountdownText = styled(Typography)(({ theme }) => ({
+  fontSize: "16px",
+  fontWeight: 400,
+  color: theme.palette.text.primary,
+  maxWidth: "500px",
+  lineHeight: 1.6,
+  [theme.breakpoints.down("sm")]: {
+    fontSize: "14px",
+  },
+}))
+
+const CountdownTimer = styled(Typography)(({ theme }) => ({
+  fontSize: "96px",
+  fontWeight: 700,
+  lineHeight: 1,
+  background: dclColors.gradient.flare,
+  backgroundClip: "text",
+  WebkitBackgroundClip: "text",
+  WebkitTextFillColor: "transparent",
+  marginTop: theme.spacing(2),
+  [theme.breakpoints.down("sm")]: {
+    fontSize: "56px",
+  },
+}))
+
+export { CountdownText, CountdownTimer, CountdownTitle, CountdownWrapper }

--- a/src/components/LiveLeaderboard/Countdown/Countdown.tsx
+++ b/src/components/LiveLeaderboard/Countdown/Countdown.tsx
@@ -1,0 +1,67 @@
+import { type FC, memo, useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  type TimeRemaining,
+  calculateTimeRemaining,
+} from "../../../utils/dateUtils"
+import {
+  CountdownText,
+  CountdownTimer,
+  CountdownTitle,
+  CountdownWrapper,
+} from "./Countdown.styled"
+
+type CountdownProps = {
+  month: string
+  startDay: number
+}
+
+const getExpireDate = (startDay: number): Date => {
+  const now = new Date()
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), startDay, 0, 0, 0)
+  )
+}
+
+export const Countdown: FC<CountdownProps> = memo(({ month, startDay }) => {
+  const { t } = useTranslation()
+  const expireDate = useMemo(() => getExpireDate(startDay), [startDay])
+  const [timeRemaining, setTimeRemaining] = useState<TimeRemaining>(
+    calculateTimeRemaining(expireDate)
+  )
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const newTime = calculateTimeRemaining(expireDate)
+      setTimeRemaining(newTime)
+
+      if (
+        newTime.hours === 0 &&
+        newTime.minutes === 0 &&
+        newTime.seconds === 0
+      ) {
+        window.location.reload()
+      }
+    }, 1000)
+
+    return () => clearInterval(interval)
+  }, [expireDate])
+
+  const timerDisplay = `${String(timeRemaining.hours).padStart(2, "0")}:${String(timeRemaining.minutes).padStart(2, "0")}:${String(timeRemaining.seconds).padStart(2, "0")}`
+
+  return (
+    <CountdownWrapper>
+      <CountdownTitle>
+        {t("liveLeaderboard.countdown.title", { month })}
+      </CountdownTitle>
+      <CountdownText>
+        {t("liveLeaderboard.countdown.description")}{" "}
+        {t("liveLeaderboard.countdown.subtitle", {
+          month,
+          day: startDay,
+        })}
+      </CountdownText>
+      <CountdownTimer>{timerDisplay}</CountdownTimer>
+    </CountdownWrapper>
+  )
+})

--- a/src/components/LiveLeaderboard/Countdown/index.ts
+++ b/src/components/LiveLeaderboard/Countdown/index.ts
@@ -1,0 +1,1 @@
+export { Countdown } from "./Countdown"

--- a/src/components/LiveLeaderboard/LiveLeaderboard.tsx
+++ b/src/components/LiveLeaderboard/LiveLeaderboard.tsx
@@ -1,9 +1,10 @@
-import { type FC, memo, useEffect, useMemo } from "react"
+import { type FC, memo, useCallback, useEffect, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { CircularProgress, ScenesTable, dclTable } from "decentraland-ui2"
 import { ROUTES } from "../../AppRoutes"
 import { getCurrentMonthKey } from "../../utils/dateUtils"
+import { openJumpIn } from "../../utils/jumpUtils"
 import { scrollToLeaderboard } from "../../utils/scrollUtils"
 import { BestNewScene } from "../BestNewScene"
 import { Countdown } from "./Countdown"
@@ -54,6 +55,12 @@ export const LiveLeaderboard: FC<LiveLeaderboardProps> = memo(
       useGetRanking()
 
     const currentMonth = t(`previousWinners.months.${getCurrentMonthKey()}`)
+
+    const handleMobileRowClick = useCallback((row: { location?: string }) => {
+      if (row.location) {
+        openJumpIn(row.location)
+      }
+    }, [])
 
     useEffect(() => {
       if (!scrollOnLoad || isLoading) return
@@ -106,9 +113,17 @@ export const LiveLeaderboard: FC<LiveLeaderboardProps> = memo(
               hoverEffect={false}
             />
           </RankTableWrapper>
-          <ScenesTable rows={sceneRows} />
+          <ScenesTable
+            rows={sceneRows}
+            onMobileRowClick={handleMobileRowClick}
+          />
         </TablesWrapper>
-        {bestNewScene && <BestNewScene sceneRow={bestNewScene} />}
+        {bestNewScene && (
+          <BestNewScene
+            sceneRow={bestNewScene}
+            onMobileRowClick={handleMobileRowClick}
+          />
+        )}
       </LiveLeaderboardContainer>
     )
   }

--- a/src/components/LiveLeaderboard/LiveLeaderboard.tsx
+++ b/src/components/LiveLeaderboard/LiveLeaderboard.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, useEffect } from "react"
+import { type FC, memo, useEffect, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { CircularProgress, ScenesTable, dclTable } from "decentraland-ui2"
@@ -6,6 +6,7 @@ import { ROUTES } from "../../AppRoutes"
 import { getCurrentMonthKey } from "../../utils/dateUtils"
 import { scrollToLeaderboard } from "../../utils/scrollUtils"
 import { BestNewScene } from "../BestNewScene"
+import { Countdown } from "./Countdown"
 import { useGetRanking } from "./useGetRanking"
 import {
   LiveLeaderboardContainer,
@@ -35,10 +36,20 @@ type LiveLeaderboardProps = {
   scrollOnLoad?: boolean
 }
 
+const LEADERBOARD_START_DAY = 4
+
+const isLeaderboardAvailable = (): boolean => {
+  const now = new Date()
+  return now.getUTCDate() >= LEADERBOARD_START_DAY
+}
+
 export const LiveLeaderboard: FC<LiveLeaderboardProps> = memo(
   ({ scrollOnLoad }) => {
     const { t } = useTranslation()
     const navigate = useNavigate()
+
+    const showLeaderboard = useMemo(() => isLeaderboardAvailable(), [])
+
     const { sceneRows, positionRows, bestNewScene, isLoading, isError } =
       useGetRanking()
 
@@ -49,6 +60,17 @@ export const LiveLeaderboard: FC<LiveLeaderboardProps> = memo(
       scrollToLeaderboard()
       navigate(ROUTES.HOME, { replace: true })
     }, [scrollOnLoad, isLoading, navigate])
+
+    if (!showLeaderboard) {
+      return (
+        <LiveLeaderboardContainer id="leaderboard">
+          <LiveLeaderboardTitle>
+            {t("liveLeaderboard.title", { month: currentMonth })}
+          </LiveLeaderboardTitle>
+          <Countdown month={currentMonth} startDay={LEADERBOARD_START_DAY} />
+        </LiveLeaderboardContainer>
+      )
+    }
 
     if (isLoading) {
       return (

--- a/src/components/Pages/TopScenesPage/TopScenesPage.styled.ts
+++ b/src/components/Pages/TopScenesPage/TopScenesPage.styled.ts
@@ -24,4 +24,9 @@ const ContentWrapper = styled(Box)(({ theme }) => ({
   },
 }))
 
-export { ContentWrapper, PageContainer }
+const FooterWrapper = styled(Box)(() => ({
+  width: "100%",
+  marginTop: "auto",
+}))
+
+export { ContentWrapper, FooterWrapper, PageContainer }

--- a/src/components/Pages/TopScenesPage/TopScenesPage.tsx
+++ b/src/components/Pages/TopScenesPage/TopScenesPage.tsx
@@ -1,17 +1,12 @@
 import { type FC, memo } from "react"
 import { useLocation, useParams } from "react-router-dom"
 import { usePageTracking } from "@dcl/hooks"
-import { FooterLanding } from "decentraland-ui2"
 import { ROUTES } from "../../../AppRoutes"
 import { Banner } from "../../Banner"
 import { LiveLeaderboard } from "../../LiveLeaderboard"
 import { MobileTabs } from "../../MobileTabs"
 import { PreviousWinners } from "../../PreviousWinners"
-import {
-  ContentWrapper,
-  FooterWrapper,
-  PageContainer,
-} from "./TopScenesPage.styled"
+import { ContentWrapper, PageContainer } from "./TopScenesPage.styled"
 
 export const TopScenesPage: FC = memo(() => {
   const { pathname } = useLocation()
@@ -32,9 +27,6 @@ export const TopScenesPage: FC = memo(() => {
         <LiveLeaderboard scrollOnLoad={isLeaderboardRoute} />
       </ContentWrapper>
       <MobileTabs initialMonth={month} isLeaderboard={isLeaderboardRoute} />
-      <FooterWrapper>
-        <FooterLanding />
-      </FooterWrapper>
     </PageContainer>
   )
 })

--- a/src/components/Pages/TopScenesPage/TopScenesPage.tsx
+++ b/src/components/Pages/TopScenesPage/TopScenesPage.tsx
@@ -1,12 +1,17 @@
 import { type FC, memo } from "react"
 import { useLocation, useParams } from "react-router-dom"
 import { usePageTracking } from "@dcl/hooks"
+import { FooterLanding } from "decentraland-ui2"
 import { ROUTES } from "../../../AppRoutes"
 import { Banner } from "../../Banner"
 import { LiveLeaderboard } from "../../LiveLeaderboard"
 import { MobileTabs } from "../../MobileTabs"
 import { PreviousWinners } from "../../PreviousWinners"
-import { ContentWrapper, PageContainer } from "./TopScenesPage.styled"
+import {
+  ContentWrapper,
+  FooterWrapper,
+  PageContainer,
+} from "./TopScenesPage.styled"
 
 export const TopScenesPage: FC = memo(() => {
   const { pathname } = useLocation()
@@ -27,6 +32,9 @@ export const TopScenesPage: FC = memo(() => {
         <LiveLeaderboard scrollOnLoad={isLeaderboardRoute} />
       </ContentWrapper>
       <MobileTabs initialMonth={month} isLeaderboard={isLeaderboardRoute} />
+      <FooterWrapper>
+        <FooterLanding />
+      </FooterWrapper>
     </PageContainer>
   )
 })

--- a/src/components/PreviousWinners/PreviousWinners.styled.ts
+++ b/src/components/PreviousWinners/PreviousWinners.styled.ts
@@ -144,6 +144,13 @@ const ScenesGrid = styled(Box)(({ theme }) => ({
   },
 }))
 
+const ClickableSceneWrapper = styled(Box)(({ theme }) => ({
+  cursor: "default",
+  [theme.breakpoints.down("sm")]: {
+    cursor: "pointer",
+  },
+}))
+
 const LoadingWrapper = styled(Box)(({ theme }) => ({
   display: "none",
   alignItems: "center",
@@ -156,6 +163,7 @@ const LoadingWrapper = styled(Box)(({ theme }) => ({
 }))
 
 export {
+  ClickableSceneWrapper,
   LoadingWrapper,
   MonthSelect,
   PreviousWinnersContainer,

--- a/src/components/PreviousWinners/PreviousWinners.tsx
+++ b/src/components/PreviousWinners/PreviousWinners.tsx
@@ -1,4 +1,4 @@
-import { type FC, memo, useEffect, useState } from "react"
+import { type FC, memo, useCallback, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import {
@@ -7,14 +7,18 @@ import {
   SceneCard,
   SelectChangeEvent,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from "decentraland-ui2"
 import { useGetPreviousWinners } from "./useGetPreviousWinners"
 import { ROUTES } from "../../AppRoutes"
 import { parseMonthParam } from "../../utils/dateUtils"
+import { openJumpIn } from "../../utils/jumpUtils"
 import { getBorderColor } from "../../utils/rankColors"
 import { scrollToRanking } from "../../utils/scrollUtils"
 import { RankingBadge } from "../RankingBadge"
 import {
+  ClickableSceneWrapper,
   LoadingWrapper,
   MonthSelect,
   PreviousWinnersContainer,
@@ -32,10 +36,21 @@ export const PreviousWinners: FC<PreviousWinnersProps> = memo(
   ({ initialMonth, scrollOnLoad }) => {
     const { t } = useTranslation()
     const navigate = useNavigate()
+    const theme = useTheme()
+    const isMobile = useMediaQuery(theme.breakpoints.down("sm"))
     const [selectedPeriod, setSelectedPeriod] = useState("")
 
     const { scenes, bestNewScene, availablePeriods, isLoading } =
       useGetPreviousWinners(selectedPeriod)
+
+    const handleCardClick = useCallback(
+      (coordinates: string) => {
+        if (isMobile) {
+          openJumpIn(coordinates)
+        }
+      },
+      [isMobile]
+    )
 
     useEffect(() => {
       if (availablePeriods.length === 0 || selectedPeriod) return
@@ -94,29 +109,36 @@ export const PreviousWinners: FC<PreviousWinnersProps> = memo(
         </PreviousWinnersHeader>
         <ScenesGrid key={selectedPeriod}>
           {scenes.map((scene, index) => (
-            <SceneCard
+            <ClickableSceneWrapper
               key={scene.id}
-              image={scene.image}
-              sceneName={scene.sceneName}
-              avatar={scene.avatar}
-              withShadow
-              borderColor={getBorderColor(index + 1)}
-              cornerBadge={<RankingBadge rank={index + 1} />}
-              coordinates={scene.coordinates}
-              showOnHover={["location", "jumpInButton"]}
-            />
+              onClick={() => handleCardClick(scene.coordinates)}
+            >
+              <SceneCard
+                image={scene.image}
+                sceneName={scene.sceneName}
+                avatar={scene.avatar}
+                withShadow
+                borderColor={getBorderColor(index + 1)}
+                cornerBadge={<RankingBadge rank={index + 1} />}
+                coordinates={scene.coordinates}
+                showOnHover={["location", "jumpInButton"]}
+              />
+            </ClickableSceneWrapper>
           ))}
           {bestNewScene && (
-            <SceneCard
-              key={bestNewScene.id}
-              image={bestNewScene.image}
-              sceneName={bestNewScene.sceneName}
-              avatar={bestNewScene.avatar}
-              withShadow
-              cornerBadge={<RankingBadge rank={0} isNew />}
-              coordinates={bestNewScene.coordinates}
-              showOnHover={["location", "jumpInButton"]}
-            />
+            <ClickableSceneWrapper
+              onClick={() => handleCardClick(bestNewScene.coordinates)}
+            >
+              <SceneCard
+                image={bestNewScene.image}
+                sceneName={bestNewScene.sceneName}
+                avatar={bestNewScene.avatar}
+                withShadow
+                cornerBadge={<RankingBadge rank={0} isNew />}
+                coordinates={bestNewScene.coordinates}
+                showOnHover={["location", "jumpInButton"]}
+              />
+            </ClickableSceneWrapper>
           )}
         </ScenesGrid>
       </PreviousWinnersContainer>

--- a/src/components/PreviousWinners/PreviousWinners.tsx
+++ b/src/components/PreviousWinners/PreviousWinners.tsx
@@ -7,11 +7,10 @@ import {
   SceneCard,
   SelectChangeEvent,
   Typography,
-  useMediaQuery,
-  useTheme,
 } from "decentraland-ui2"
 import { useGetPreviousWinners } from "./useGetPreviousWinners"
 import { ROUTES } from "../../AppRoutes"
+import { useIsMobile } from "../../hooks/useIsMobile"
 import { parseMonthParam } from "../../utils/dateUtils"
 import { openJumpIn } from "../../utils/jumpUtils"
 import { getBorderColor } from "../../utils/rankColors"
@@ -36,8 +35,7 @@ export const PreviousWinners: FC<PreviousWinnersProps> = memo(
   ({ initialMonth, scrollOnLoad }) => {
     const { t } = useTranslation()
     const navigate = useNavigate()
-    const theme = useTheme()
-    const isMobile = useMediaQuery(theme.breakpoints.down("sm"))
+    const isMobile = useIsMobile()
     const [selectedPeriod, setSelectedPeriod] = useState("")
 
     const { scenes, bestNewScene, availablePeriods, isLoading } =

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,6 @@
+import { useMediaQuery, useTheme } from "decentraland-ui2"
+
+export const useIsMobile = (): boolean => {
+  const theme = useTheme()
+  return useMediaQuery(theme.breakpoints.down("sm"))
+}

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -25,7 +25,12 @@
   "liveLeaderboard": {
     "title": "Live {{month}} Leaderboard",
     "error": "Error loading rankings",
-    "rankHeader": "Rank"
+    "rankHeader": "Rank",
+    "countdown": {
+      "title": "{{month}} Leaderboard has kicked off!",
+      "description": "Build and refine your scene to boost your chances.",
+      "subtitle": "The live ranking will appear on {{month}} {{day}}th."
+    }
   },
   "bestNewScene": {
     "title": "Best New Scene",

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,3 +1,9 @@
+type TimeRemaining = {
+  hours: number
+  minutes: number
+  seconds: number
+}
+
 const parseMonthParam = (month: string | undefined): string | null => {
   if (!month || month.length !== 4) return null
   const mm = month.slice(0, 2)
@@ -10,4 +16,16 @@ const getCurrentMonthKey = (): string => {
   return String(now.getUTCMonth() + 1).padStart(2, "0")
 }
 
-export { getCurrentMonthKey, parseMonthParam }
+const calculateTimeRemaining = (expireDate: Date): TimeRemaining => {
+  const now = new Date()
+  const diff = Math.max(0, expireDate.getTime() - now.getTime())
+
+  const totalHours = Math.floor(diff / (1000 * 60 * 60))
+  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60))
+  const seconds = Math.floor((diff % (1000 * 60)) / 1000)
+
+  return { hours: totalHours, minutes, seconds }
+}
+
+export { calculateTimeRemaining, getCurrentMonthKey, parseMonthParam }
+export type { TimeRemaining }

--- a/src/utils/jumpUtils.ts
+++ b/src/utils/jumpUtils.ts
@@ -1,0 +1,16 @@
+import { isEns } from "../features/places"
+
+const JUMP_BASE_URL = "https://decentraland.org/jump/"
+
+const getJumpInUrl = (coordinates: string): string => {
+  if (isEns(coordinates)) {
+    return `${JUMP_BASE_URL}?realm=${coordinates}`
+  }
+  return `${JUMP_BASE_URL}?position=${coordinates}`
+}
+
+const openJumpIn = (coordinates: string): void => {
+  window.open(getJumpInUrl(coordinates), "_blank")
+}
+
+export { getJumpInUrl, openJumpIn }


### PR DESCRIPTION
## Changes Summary

### 1. Countdown
- Shows countdown timer (`HH:MM:SS`) if UTC date < 4th of the month
- Auto-reloads when timer reaches zero to display leaderboard

### 2. Mobile Click (Jump In)
- Tapping rows/cards on mobile opens Decentraland jump URL in new tab

### 3. Footer
- Added LandingFooter from ui2
<img width="1491" height="437" alt="Screenshot 2025-12-29 at 17 29 07" src="https://github.com/user-attachments/assets/18c9e129-d91d-407d-95c8-fc2635ef1563" />
<img width="1512" height="586" alt="Screenshot 2025-12-29 at 19 02 40" src="https://github.com/user-attachments/assets/5e757cbf-e0eb-461a-8f3b-9ba6d2482279" />
