### PR TITLE
feat: fix img style and hide ranking on null data

### DIFF
--- a/src/components/LiveLeaderboard/LiveLeaderboard.styled.ts
+++ b/src/components/LiveLeaderboard/LiveLeaderboard.styled.ts
@@ -39,8 +39,8 @@ const TablesWrapper = styled(Box)(({ theme }) => ({
   },
   "& .MuiTableCell-root img": {
     width: "100px",
-    minWidth: "100",
-    maxWidth: "100x",
+    minWidth: "100px",
+    objectFit: "fill",
   },
   [theme.breakpoints.down("sm")]: {
     "& .MuiTableCell-root img": {

--- a/src/features/scenes/scenes.client.ts
+++ b/src/features/scenes/scenes.client.ts
@@ -34,7 +34,10 @@ const scenesApi = scenesClient.injectEndpoints({
             contactName,
             ranking,
             lastEventRegisteredAt,
-            positionChange: previousRanking - ranking,
+            positionChange:
+              previousRanking !== null && ranking !== null
+                ? previousRanking - ranking
+                : 0,
           })
         ),
       providesTags: ["SceneRanking"],


### PR DESCRIPTION
## Fixes
- The ranking position change calculation (`previousRanking - ranking`) could produce unexpected results if either value came as `null` from the CDN. Added null validation in the position change calculation. If `previousRanking` or `ranking` is `null`, it returns `0` (no change).
- Changing css for images on table so they resize instead of cutting
