### PR TITLE
feat: fix order of previous winners 

### DIFF
--- a/src/components/LiveLeaderboard/useGetRanking.ts
+++ b/src/components/LiveLeaderboard/useGetRanking.ts
@@ -43,7 +43,13 @@ export const useGetRanking = () => {
 
   const creatorAddresses = useMemo(() => {
     if (!data) return []
-    return [...new Set(data.map((scene) => scene.creator.toLowerCase()))]
+    return [
+      ...new Set(
+        data
+          .map((scene) => scene.creator.toLowerCase())
+          .filter((addr) => addr && addr.startsWith("0x"))
+      ),
+    ]
   }, [data])
 
   const { positions, worlds } = useMemo(() => {

--- a/src/components/LiveLeaderboard/useGetRanking.ts
+++ b/src/components/LiveLeaderboard/useGetRanking.ts
@@ -7,6 +7,7 @@ import {
 import { isEns, useGetPlacesAndWorldsQuery } from "../../features/places"
 import { useGetProfilesQuery } from "../../features/profiles"
 import { useGetCurrentMonthRankingQuery } from "../../features/scenes"
+import { extractValidCreatorAddresses } from "../../utils/addressUtils"
 import { isValidPosition } from "../../utils/locationUtils"
 import { getBorderColor } from "../../utils/rankColors"
 
@@ -41,16 +42,10 @@ export const useGetRanking = () => {
     return { rankings, bestNewSceneRanking: bestNew || null }
   }, [data])
 
-  const creatorAddresses = useMemo(() => {
-    if (!data) return []
-    return [
-      ...new Set(
-        data
-          .map((scene) => scene.creator.toLowerCase())
-          .filter((addr) => addr && addr.startsWith("0x"))
-      ),
-    ]
-  }, [data])
+  const creatorAddresses = useMemo(
+    () => extractValidCreatorAddresses(data ?? []),
+    [data]
+  )
 
   const { positions, worlds } = useMemo(() => {
     if (!data) return { positions: [], worlds: [] }

--- a/src/components/PreviousWinners/useGetPreviousWinners.ts
+++ b/src/components/PreviousWinners/useGetPreviousWinners.ts
@@ -80,7 +80,12 @@ export const useGetPreviousWinners = (selectedPeriod: string) => {
 
   const availablePeriods = useMemo(() => {
     if (!rankingsByPeriod) return []
-    return Object.keys(rankingsByPeriod).sort().reverse()
+    return Object.keys(rankingsByPeriod).sort((a, b) => {
+      const [monthA, yearA] = a.split("/").map(Number)
+      const [monthB, yearB] = b.split("/").map(Number)
+      if (yearB !== yearA) return yearB - yearA
+      return monthB - monthA
+    })
   }, [rankingsByPeriod])
 
   const currentRankings = useMemo(() => {
@@ -91,7 +96,11 @@ export const useGetPreviousWinners = (selectedPeriod: string) => {
   const creatorAddresses = useMemo(() => {
     if (!currentRankings.length) return []
     return [
-      ...new Set(currentRankings.map((scene) => scene.creator.toLowerCase())),
+      ...new Set(
+        currentRankings
+          .map((scene) => scene.creator.toLowerCase())
+          .filter((addr) => addr && addr.startsWith("0x"))
+      ),
     ]
   }, [currentRankings])
 

--- a/src/utils/addressUtils.ts
+++ b/src/utils/addressUtils.ts
@@ -1,0 +1,12 @@
+const isValidEthAddress = (address: string): boolean =>
+  Boolean(address && address.startsWith("0x"))
+
+const extractValidCreatorAddresses = <T extends { creator: string }>(
+  items: T[]
+): string[] => [
+  ...new Set(
+    items.map((item) => item.creator.toLowerCase()).filter(isValidEthAddress)
+  ),
+]
+
+export { extractValidCreatorAddresses, isValidEthAddress }

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -27,5 +27,18 @@ const calculateTimeRemaining = (expireDate: Date): TimeRemaining => {
   return { hours: totalHours, minutes, seconds }
 }
 
-export { calculateTimeRemaining, getCurrentMonthKey, parseMonthParam }
+const sortPeriodsByDate = (periods: string[]): string[] =>
+  [...periods].sort((a, b) => {
+    const [monthA, yearA] = a.split("/").map(Number)
+    const [monthB, yearB] = b.split("/").map(Number)
+    if (yearB !== yearA) return yearB - yearA
+    return monthB - monthA
+  })
+
+export {
+  calculateTimeRemaining,
+  getCurrentMonthKey,
+  parseMonthParam,
+  sortPeriodsByDate,
+}
 export type { TimeRemaining }


### PR DESCRIPTION
**Fix Previous Winners month sorting and profile loading**

- Month sorting was incorrect: When December 2025 and January 2026 were both available, January 2026 appeared at the bottom of the dropdown instead of first. This happened because the periods (MM/YY format) were being sorted alphabetically, causing "01/26" to come before "12/25" alphabetically, but after when reversed.

- Profiles/Avatars not displaying: Some scene rankings in the API have empty creator fields. These empty strings were being sent to the profiles API, causing issues with profile loading.

**Before** 
<img width="1498" height="386" alt="Screenshot 2026-02-04 at 17 31 51" src="https://github.com/user-attachments/assets/32f37060-8dcc-4dd8-b98f-4bb5b2f7b3c0" />

**After**
<img width="1026" height="488" alt="Screenshot 2026-02-04 at 17 32 11" src="https://github.com/user-attachments/assets/d2ad03a8-cc67-487b-adb5-0ec0e0594099" />

- Fixed month sorting: Replaced simple string sort with a custom comparator that parses month and year separately, comparing years first (descending), then months (descending).
- 
- Filter invalid creator addresses: Added a filter to exclude empty or invalid addresses (those not starting with 0x) before fetching profiles. This prevents API errors and ensures valid profiles are fetched correctly.
